### PR TITLE
fix: improve AI product review image handling

### DIFF
--- a/src/components/ai-upload/ProcessingProgress.tsx
+++ b/src/components/ai-upload/ProcessingProgress.tsx
@@ -58,12 +58,6 @@ const ProcessingProgress: React.FC<ProcessingProgressProps> = ({ files, liveProd
               Gemini AI is extracting product information page-by-page
             </p>
           </div>
-          <button
-            onClick={onUploadMore}
-            className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
-          >
-            + Upload more
-          </button>
         </div>
 
         {/* File list */}

--- a/src/components/ai-upload/ProductReviewGrid.tsx
+++ b/src/components/ai-upload/ProductReviewGrid.tsx
@@ -77,9 +77,7 @@ function ProductCard({
   const isApproved = product.status === 'approved';
   const isRejected = product.status === 'rejected';
 
-  const thumbSrc = product.images[0]
-    || product.pageImageUrl
-    || null;
+  const thumbSrc = product.images[0] || null;
 
   return (
     <div className={`


### PR DESCRIPTION
## Overview

Fix AI product preview behavior during AI extraction review.

## Changes

- Removed PDF page screenshot fallback from product cards
- Product cards now use only product.images
- Removed Upload More button during processing state

## Result

- Actual product images are displayed correctly
- Products without images show No preview
- PDF source screenshots remain separate